### PR TITLE
Fix reaction rate scaling by volume in new compartment

### DIFF
--- a/src/Chemistry/Reaction.cpp
+++ b/src/Chemistry/Reaction.cpp
@@ -95,7 +95,7 @@ Reaction<M,N>* Reaction<M,N>::cloneImpl(const SpeciesPtrContainerVector &spcv)
         else species.push_back(vit->get());
     }
     //Create new reaction, copy ownership of signal
-    Reaction* newReaction = new Reaction<M,N>(species, _rate_bare);
+    Reaction* newReaction = new Reaction<M,N>(species, _rate_bare, _isProtoCompartment, _volumeFrac, _rateVolumeDepExp);
     newReaction->_rate = _rate;
     newReaction->_Id = _Id;
 #ifdef REACTION_SIGNALING

--- a/src/Chemistry/ReactionBase.h
+++ b/src/Chemistry/ReactionBase.h
@@ -250,9 +250,6 @@ public:
     ///Get CBound
     CBound* getCBound() {return _cBound;}
     
-    /// Sets the ReactionBase rate to the parameter "rate"
-    [[deprecated]]void setRate(float rate) {_rate=rate;}
-    
     // Sets the scaled rate based on volume dependence.
     void recalcRateVolumeFactor() {
         // This can automatically set the "_rate" as scaled value of "rate"
@@ -275,7 +272,10 @@ public:
     
     /// Getter and setter for compartment volume fraction
     floatingpoint getVolumeFrac()const { return _volumeFrac; }
-    void setVolumeFrac(float volumeFrac) { _volumeFrac = volumeFrac; }
+    void setVolumeFrac(float volumeFrac) {
+        _volumeFrac = volumeFrac;
+        recalcRateVolumeFactor();
+    }
     
     /// Sets the RNode pointer associated with this ReactionBase to rhs. Usually is
     /// called only by the Gillespie-like algorithms.

--- a/src/Structure/CCylinder.cpp
+++ b/src/Structure/CCylinder.cpp
@@ -41,6 +41,7 @@ CCylinder::CCylinder(const CCylinder& rhs, Compartment* c)
     //copy all internal reactions
     for(auto &r: rhs._internalReactions) {
         ReactionBase* rxnClone = r->clone(c->getSpeciesContainer());
+        rxnClone->setVolumeFrac(c->getVolumeFrac());
         
         if(r->getCBound() != nullptr)
             r->getCBound()->setOffReaction(rxnClone);
@@ -57,6 +58,7 @@ CCylinder::CCylinder(const CCylinder& rhs, Compartment* c)
 
             //copy cbound if any
             ReactionBase* rxnClone = r->clone(c->getSpeciesContainer());
+            rxnClone->setVolumeFrac(c->getVolumeFrac());
             
             if(r->getCBound() != nullptr) {
 	            #ifdef CHECKRXN
@@ -83,6 +85,7 @@ CCylinder::CCylinder(const CCylinder& rhs, Compartment* c)
             
             //copy cbound if any
             ReactionBase* rxnClone = r->clone(c->getSpeciesContainer());
+            rxnClone->setVolumeFrac(c->getVolumeFrac());
 
             if(r->getCBound() != nullptr) {
                 #ifdef CHECKRXN

--- a/src/Structure/Compartment.h
+++ b/src/Structure/Compartment.h
@@ -722,6 +722,7 @@ public:
         for(auto &r : _internal_reactions.reactions()){
 
             auto rClone = r->clone(target->_species);
+            rClone->setVolumeFrac(target->getVolumeFrac());
             target->addInternalReaction(rClone);
         }
     }


### PR DESCRIPTION
# Overview
Fixes the problem that the reactions were not rescaled by volume when elements move across compartments.

# Changes
The idea is to simply reset the volume fraction for reactions cloned to new compartments, by calling `ReactionBase::setVolumeFrac(...)` after cloning.

Now `ReactionBase::setVolumeFrac(...)` will also reset the volume scaling factor, as well as the actual rate. The deprecated `Reaction::setRate(...)` is removed, so one is not allowed to directly modify the actual rate. Currently, resetting the bare rate, the rate multiplication factor or the volume fraction will all change the actual rate consistently. One caveat is that one should not directly change the rate `VOLUMEFACTOR`, but should rather call `ReactionBase::setVolumeFrac(...)`, which will automatically handle the volumetric rate factor.

An illustration is below, where the values on the right depend on the values on the left
```
volume frac ---
               | -------- volume factor ------
volume exp  ---                              |
                 mechanochemical factor ------
                                             | ------ actual rate
                       other factors... ------
                                             |
                              bare rate ------
```

`ReactionBase::clone()` will continue to do what it should do: to create a duplicate of the reaction that is as identical to the original reaction as possible. It will not handle the volume fraction or the rate rescaling.